### PR TITLE
Updating license in package.json to AGPL-3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "keywords": [
     "gatsby"
   ],
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "scripts": {
     "build": "npm run acrollout && gatsby build",
     "acrollout": "node scripts/allcontributors-transformer.js",


### PR DESCRIPTION
Closes: #228 

This small PR fixes the following issue: The project is using "GNU Affero General Public License v3.0" as shown in ./LICENSE however package.json shows "license": "MIT"