### PR TITLE
Fixed Safari Height Issue for Fellows & Projects Component

### DIFF
--- a/src/modules/fellows/Fellows.js
+++ b/src/modules/fellows/Fellows.js
@@ -14,63 +14,66 @@ const Fellows = () => {
         borderRadius: 'medium',
         marginX: ['2rem', '2rem', '0rem']
       }}>
-      <Grid
-        id="fellowContainer"
-        gap={0}
-        columns={2}
-        sx={{
-          gridColumnGap: ['2rem', '4rem'],
-          gridRowGap: ['2.5rem', '4rem'],
-          paddingBottom: ['0rem', '0rem'],
-          overflowX: 'scroll',
-          paddingX: '2rem',
-          paddingTop: '2rem',
-          gridTemplateRows: ['auto auto auto', 'auto auto'],
-          gridAutoFlow: 'column',
-          borderRadius: '0.5rem',
-          scrollBehavior: 'smooth',
-          scrollbarWidth: 'none'
-        }}>
-        {originalArray.fellows.map((fellow, index) => (
-          <Flex
-            key={index}
-            sx={{
-              flexDirection: 'column',
-              ':hover': {
-                cursor: 'pointer',
-                color: 'primary'
-              },
-              minWidth: [60, 100],
-              maxWidth: [60, 100],
-              minHeight: [60, 150],
-              maxHeight: [60, 150]
-            }}
-            onClick={() => {
-              window.open(fellow.url, '_blank');
-            }}>
-            <Image
-              src={fellow.image}
+      <Flex>
+        <Grid
+          id="fellowContainer"
+          sx={{
+            gridColumnGap: ['2rem', '4rem'],
+            gridRowGap: ['2.5rem', '3rem'],
+            paddingBottom: ['0rem', '0rem'],
+            overflowX: 'scroll',
+            height: ['428px', '392px'],
+            paddingX: '2rem',
+            paddingTop: '2rem',
+            gridTemplateRows: ['auto auto auto', 'auto auto'],
+            gridAutoFlow: 'column',
+            borderRadius: '0.5rem',
+            scrollBehavior: 'smooth',
+            scrollbarWidth: 'none',
+            webkitScrollbarWidth: 'none'
+          }}>
+          {originalArray.fellows.map((fellow, index) => (
+            <Flex
+              key={index}
               sx={{
-                borderRadius: '100%',
-                marginX: 'auto',
-                marginBottom: '0.5rem'
+                flexDirection: 'column',
+                ':hover': {
+                  cursor: 'pointer',
+                  color: 'primary'
+                },
+                minWidth: [60, 100],
+                maxWidth: [60, 100],
+                minHeight: [60, 150],
+                maxHeight: [60, 150]
               }}
-            />
-
-            <Text
-              sx={{
-                textAlign: 'center',
-                fontSize: ['0.8rem', '1rem']
+              onClick={() => {
+                window.open(fellow.url, '_blank');
               }}>
-              {fellow.name}
-            </Text>
-          </Flex>
-        ))}
-      </Grid>
+              <Image
+                src={fellow.image}
+                sx={{
+                  borderRadius: '100%',
+                  marginX: 'auto',
+                  marginBottom: '0.5rem'
+                }}
+              />
+
+              <Text
+                sx={{
+                  textAlign: 'center',
+                  fontSize: ['0.8rem', '1rem']
+                }}>
+                {fellow.name}
+              </Text>
+            </Flex>
+          ))}
+        </Grid>
+      </Flex>
       <Flex
         sx={{
           marginX: 'auto',
-          marginBottom: ['0rem', '2rem'],
+          marginBottom: ['-1rem', '1rem'],
+          marginTop: ['0rem', '1rem'],
           textColor: 'callout',
           visibility: ['hidden', 'visible']
         }}>

--- a/src/modules/projects/Projects.js
+++ b/src/modules/projects/Projects.js
@@ -14,46 +14,51 @@ const Projects = () => {
         marginX: ['2rem', '2rem', '0rem'],
         marginTop: ['-2rem', '-4rem']
       }}>
-      <Grid
-        id="projectContainer"
-        sx={{
-          gridColumnGap: ['1rem', '4rem'],
-          gridRowGap: ['4rem', '6rem'],
-          padding: '2rem',
-          overflowX: 'scroll',
-          gridTemplateRows: ['auto', 'auto'],
-          gridAutoFlow: 'column',
-          scrollBehavior: 'smooth',
-          scrollbarWidth: 'none'
-        }}>
-        {projects.map((project, index) => (
-          <Flex
-            key={index}
-            onClick={() => {
-              window.open(project.url, '_blank');
-            }}
-            sx={{
-              flexDirection: 'column',
-              rowGap: '1rem',
-              ':hover': {
-                cursor: 'pointer',
-                color: 'primary'
-              },
-              minWidth: '344px'
-            }}>
-            <Image
-              sx={{borderRadius: '3%', width: '344px', height: '206px'}}
-              src={project.image}
-            />
-            <Text sx={{fontWeight: 600, fontSize: '24px'}}>{project.name}</Text>
-            <Text sx={{color: 'text'}}>{project.description}</Text>
-          </Flex>
-        ))}
-      </Grid>
+      <Flex>
+        <Grid
+          id="projectContainer"
+          sx={{
+            gridColumnGap: ['1rem', '4rem'],
+            gridRowGap: ['4rem', '6rem'],
+            padding: '2rem',
+            overflowX: 'scroll',
+            gridTemplateRows: ['auto', 'auto'],
+            gridAutoFlow: 'column',
+            scrollBehavior: 'smooth',
+            scrollbarWidth: 'none'
+          }}>
+          {projects.map((project, index) => (
+            <Flex
+              key={index}
+              onClick={() => {
+                window.open(project.url, '_blank');
+              }}
+              sx={{
+                flexDirection: 'column',
+                rowGap: '1rem',
+                ':hover': {
+                  cursor: 'pointer',
+                  color: 'primary'
+                },
+                minWidth: '344px'
+              }}>
+              <Image
+                sx={{borderRadius: '3%', width: '344px', height: '206px'}}
+                src={project.image}
+              />
+              <Text sx={{fontWeight: 600, fontSize: '24px'}}>
+                {project.name}
+              </Text>
+              <Text sx={{color: 'text'}}>{project.description}</Text>
+            </Flex>
+          ))}
+        </Grid>
+      </Flex>
       <Flex
         sx={{
           marginX: 'auto',
-          marginBottom: ['0rem', '2rem'],
+          marginBottom: ['-1rem', '1rem'],
+          marginTop: ['0rem', '1rem'],
           textColor: 'callout',
           visibility: ['hidden', 'visible']
         }}>


### PR DESCRIPTION
The current fix by Angela broke something in the Mobile View of the Fellows Component.

This is a known issue in safari documented here : 
https://stackoverflow.com/questions/55347359/why-is-css-grid-row-height-different-in-safari

For the fix, I had to add a separate `<Flex>` wrapping the `<Grid>` containing fellows and projects and some other height and padding changes as well.

<img width="373" alt="Screenshot 2022-02-04 at 7 28 35 AM" src="https://user-images.githubusercontent.com/22751053/152459943-b65b164d-4e07-4170-815c-105aa23c557f.png">

