### PR TITLE
Handle connecting to Metamask and displaying register modal

### DIFF
--- a/src/modules/flashcard/card.js
+++ b/src/modules/flashcard/card.js
@@ -33,6 +33,8 @@ const Card = ({
   const [isUserRegistered, setIsUserRegistered] = React.useState(false);
   const provider = useProvider();
 
+  const [isModalVisible, setModalVisible] = React.useState(false);
+
   useEffect(() => {
     async function get() {
       setIsUserRegistered(await isRegistered(accountData.address, provider));
@@ -56,7 +58,8 @@ const Card = ({
           position: 'relative',
           zIndex: 1,
           boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)'
-        }}>
+        }}
+      >
         <Flex
           sx={{
             p: 3,
@@ -65,7 +68,8 @@ const Card = ({
             textAlign: 'center',
             justifyContent: 'center',
             flex: '1 1 auto'
-          }}>
+          }}
+        >
           ERROR! Incorrect # of Children for Card. Please check your mdx.
         </Flex>
       </Flex>
@@ -95,10 +99,20 @@ const Card = ({
   const currentVariant = isActive ? 'active' : wasActive ? 'exit' : 'initial';
   const inactiveScale = 1 - 0.05 * (index - currentCard);
 
+  const handleOnClickMetamask = () => {
+    connect(data.connectors[Connector.INJECTED]).then((result) => {
+      if (!result.error) {
+        setModalVisible(true);
+      }
+    });
+  };
+
   return (
     <motion.div variants={cardVariants} animate={currentVariant}>
-      {/* If User is Not Registered and Wallet is Connected Display Modal */}
-      {!isUserRegistered && data.connected && <Modal />}
+      <Modal
+        setModalVisible={setModalVisible}
+        isModalVisible={isModalVisible}
+      />
       <Flex
         sx={{
           width: ['100%', '343px', '343px'],
@@ -113,7 +127,8 @@ const Card = ({
           transform: `scale(${isActive ? '1' : inactiveScale})`,
           transformOrigin: 'bottom',
           boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)'
-        }}>
+        }}
+      >
         {isActive && (
           <>
             <Flex
@@ -124,7 +139,8 @@ const Card = ({
                 flex: '1 1 auto',
                 p: [1, 2, 3],
                 fontSize: [2, 3, 4]
-              }}>
+              }}
+            >
               {question}
             </Flex>
             <Flex
@@ -146,7 +162,8 @@ const Card = ({
                   transition: 'all .2s ease',
                   transform: 'scale(1.1)'
                 }
-              }}>
+              }}
+            >
               <div
                 sx={{
                   position: 'absolute',
@@ -154,13 +171,15 @@ const Card = ({
                   top: '-13px',
                   height: '13px',
                   width: '100%'
-                }}></div>
+                }}
+              ></div>
               <motion.div
                 variants={revealCopyVariant}
                 initial="initial"
                 animate={isRevealed ? 'revealed' : 'initial'}
-                sx={{position: 'absolute'}}>
-                {data.connected && (
+                sx={{position: 'absolute'}}
+              >
+                {data.connected && isUserRegistered && (
                   <Flex onClick={revealCallback}>
                     <span
                       className="reveal-answer"
@@ -170,7 +189,8 @@ const Card = ({
                         fontWeight: 'bold',
                         transform: 'scale(1)',
                         transition: 'all .2s ease'
-                      }}>
+                      }}
+                    >
                       {' '}
                       Reveal the Answer
                     </span>
@@ -183,13 +203,15 @@ const Card = ({
                         <Box
                           sx={{
                             padding: '0.5rem'
-                          }}>
+                          }}
+                        >
                           <Text
                             sx={{
                               textAlign: 'center',
                               fontWeight: 'bold',
                               marginX: 'auto'
-                            }}>
+                            }}
+                          >
                             Connect wallet to reveal
                           </Text>
                         </Box>
@@ -197,9 +219,8 @@ const Card = ({
                         <Button
                           sx={{marginX: 'auto'}}
                           disabled={!data.connectors[Connector.INJECTED].ready}
-                          onClick={() =>
-                            connect(data.connectors[Connector.INJECTED])
-                          }>
+                          onClick={handleOnClickMetamask}
+                        >
                           Metamask
                         </Button>
                       </>
@@ -210,6 +231,37 @@ const Card = ({
                   </>
                 )}
               </motion.div>
+              {data.connected && !isUserRegistered && (
+                <>
+                  <div>
+                    <>
+                      <Box
+                        sx={{
+                          padding: '0.5rem'
+                        }}
+                      >
+                        <Text
+                          sx={{
+                            textAlign: 'center',
+                            fontWeight: 'bold',
+                            marginX: 'auto'
+                          }}
+                        >
+                          Register to reveal
+                        </Text>
+                      </Box>
+
+                      <Button
+                        sx={{marginX: 'auto'}}
+                        disabled={!data.connectors[Connector.INJECTED].ready}
+                        onClick={() => setModalVisible(true)}
+                      >
+                        Register
+                      </Button>
+                    </>
+                  </div>
+                </>
+              )}
               {/* Reveal answer when Wallet is Connected and User is Registered */}
               {data.connected && isUserRegistered && (
                 <motion.div
@@ -226,14 +278,16 @@ const Card = ({
                       filter: isRevealed ? 'blur(0px)' : 'blur(4px)',
                       transition: 'all .2s ease'
                     }
-                  }}>
+                  }}
+                >
                   {answer}
                   {_children.length > 2 && (
                     <motion.div
                       sx={{fontSize: '12px', mt: 2}}
                       variants={postAnswerVariant}
                       initial="initial"
-                      animate={isRevealed ? 'revealed' : 'initial'}>
+                      animate={isRevealed ? 'revealed' : 'initial'}
+                    >
                       {postAnswer}
                     </motion.div>
                   )}

--- a/src/modules/modal/modal.js
+++ b/src/modules/modal/modal.js
@@ -2,109 +2,126 @@ import React, {Children} from 'react';
 import {jsx, Flex, Text, Box, Button} from 'theme-ui';
 
 const Modal = ({isModalVisible, setModalVisible}) => {
-  return (
-    <>
-      <Box
-        sx={{
-          backgroundColor: '#47556990',
-          backgroundOpacity: 0.5,
-          width: '100%',
-          height: '100%',
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          zIndex: 10,
-          backdropFilter: 'blur(10px)',
-          alignItems: 'center',
-          justifyContent: 'center'
-        }}>
-        <Flex
+  if (isModalVisible) {
+    return (
+      <>
+        <Box
           sx={{
-            flexDirection: 'column',
-            marginY: 'auto',
-            paddingTop: '250px',
-            gap: 0
-          }}>
+            backgroundColor: '#47556990',
+            backgroundOpacity: 0.5,
+            width: '100%',
+            height: '100%',
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            zIndex: 10,
+            backdropFilter: 'blur(10px)',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+          onClick={() => {
+            setModalVisible(false);
+          }}
+        >
           <Flex
             sx={{
-              width: '471px',
-              height: '361px',
-              borderTopLeftRadius: '12px',
-              borderTopRightRadius: '12px',
-              backgroundColor: '#212144',
-              marginX: 'auto',
-              flexDirection: 'column'
-            }}>
-            <Text
+              flexDirection: 'column',
+              marginY: 'auto',
+              paddingTop: '250px',
+              gap: 0
+            }}
+          >
+            <Flex
               sx={{
-                color: '#fff',
-                textAlign: 'center',
-                margin: 'auto',
-                fontWeight: 'bold'
-              }}>
-              To reveal the answer, you need to <br /> register for our course.
-            </Text>
-            <Flex sx={{flexDirection: 'column'}}>
+                width: '471px',
+                height: '361px',
+                borderTopLeftRadius: '12px',
+                borderTopRightRadius: '12px',
+                backgroundColor: '#212144',
+                marginX: 'auto',
+                flexDirection: 'column'
+              }}
+            >
               <Text
                 sx={{
                   color: '#fff',
                   textAlign: 'center',
                   margin: 'auto',
                   fontWeight: 'bold'
-                }}>
-                You can do this by staking
+                }}
+              >
+                To reveal the answer, you need to <br /> register for our
+                course.
               </Text>
+              <Flex sx={{flexDirection: 'column'}}>
+                <Text
+                  sx={{
+                    color: '#fff',
+                    textAlign: 'center',
+                    margin: 'auto',
+                    fontWeight: 'bold'
+                  }}
+                >
+                  You can do this by staking
+                </Text>
+                <Text
+                  sx={{
+                    margin: 'auto',
+                    color: '#8C65F7',
+                    fontSize: '48px',
+                    fontWeight: 'medium'
+                  }}
+                >
+                  100 DAI
+                </Text>
+              </Flex>
               <Text
                 sx={{
-                  margin: 'auto',
-                  color: '#8C65F7',
-                  fontSize: '48px',
-                  fontWeight: 'medium'
-                }}>
-                100 DAI
+                  width: '310px',
+                  color: '#fff',
+                  textAlign: 'center',
+                  margin: 'auto'
+                }}
+              >
+                You can claim this DAI back after{' '}
+                <Text sx={{fontWeight: 'bold'}}>two months</Text>. You{' '}
+                <Text sx={{fontWeight: 'bold'}}>learn for free</Text> and we use
+                the yield to keep the lights on.
               </Text>
             </Flex>
-            <Text
+            <Flex
               sx={{
-                width: '310px',
-                color: '#fff',
-                textAlign: 'center',
-                margin: 'auto'
-              }}>
-              You can claim this DAI back after{' '}
-              <Text sx={{fontWeight: 'bold'}}>two months</Text>. You{' '}
-              <Text sx={{fontWeight: 'bold'}}>learn for free</Text> and we use
-              the yield to keep the lights on.
-            </Text>
+                width: '471px',
+                height: '100px',
+                borderBottomRightRadius: '12px',
+                borderBottomLeftRadius: '12px',
+                backgroundColor: '#343457',
+                marginX: 'auto',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingX: '20px'
+              }}
+            >
+              <Text
+                sx={{
+                  color: '#fff',
+                  textDecoration: 'underline',
+                  justifySelf: 'end'
+                }}
+              >
+                Learn More.
+              </Text>
+              <Button sx={{borderRadius: '4px', fontWeight: 'bold'}}>
+                Register
+              </Button>
+            </Flex>
           </Flex>
-          <Flex
-            sx={{
-              width: '471px',
-              height: '100px',
-              borderBottomRightRadius: '12px',
-              borderBottomLeftRadius: '12px',
-              backgroundColor: '#343457',
-              marginX: 'auto',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              paddingX: '20px'
-            }}>
-            <Text
-              sx={{
-                color: '#fff',
-                textDecoration: 'underline',
-                justifySelf: 'end'
-              }}>
-              Learn More.
-            </Text>
-            <Button sx={{borderRadius: '4px', fontWeight: 'bold'}}>
-              Register
-            </Button>
-          </Flex>
-        </Flex>
-      </Box>
-    </>
-  );
+        </Box>
+      </>
+    );
+  } else {
+    return null;
+  }
 };
 
 export default Modal;


### PR DESCRIPTION
## Summary of changes

This commit updates the logic of how the Card component handles the
various steps in connecting to a user's wallet and prompting them to
register.

When a user's currently selected Metamask account is not connected, we
display the "Connect wallet..." prompt. Upon clicking the button,
they'll be prompted to connect, and upon connecting, will be prompted
with the registration modal.

Previously, if the user clicked away and refreshed the page before
registering, the modal would pop up automatically and intrusively.
This commit changes this behavior so that if a user is in a
connected-and-unregistered state, the prompt on the card changes to
"Register to reveal". Clicking this prompt displays the registration modal.

Finally, when a user is both connected and registered, the cards answer
can be revealed.