### PR TITLE
Refactor contract calls to use wagmi hooks and integrate notificatins

### DIFF
--- a/src/course/contracts.js
+++ b/src/course/contracts.js
@@ -1,157 +1,213 @@
-import { Contract } from 'ethers'
+import { useEffect, useState } from 'react'
+import { useContractRead, useContractWrite, useProvider } from 'wagmi'
 import { addresses, abis } from './constants'
 
-const KERNEL_COURSE_ID = '0'
+import { useNotifications } from '@src/modules/notifications/context'
 
-export const isRegistered = async (learner, provider) => {
-  const { chainId } = await provider.getNetwork()
+export const KERNEL_COURSE_ID = '0'
 
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    provider
-  )
-  let res = false
-  try {
-    res = !!(await deSchoolContract.verify(learner, KERNEL_COURSE_ID))
-  } catch (err) {
-    // throws an error if either the learner is not registered or if the courseId does not exist
-    /** */
+const useGetChainId = () => {
+  const [chainId, setChainId] = useState()
+  const provider = useProvider()
+
+  useEffect(() => {
+    const getChainId = async () => {
+      const { chainId: id } = await provider.getNetwork()
+      setChainId(id)
+    }
+
+    getChainId()
+  }, [provider])
+
+  return chainId
+}
+
+export const useIsRegistered = (learner) => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
+
+  if (learner) {
+    return useContractRead(
+      {
+        addressOrName: addresses(chainId).deSchool,
+        contractInterface: abis.deSchool,
+      },
+      'verify',
+      {
+        args: [learner, KERNEL_COURSE_ID],
+        onError: (error) =>
+          queueNotification(
+            'error',
+            "Couldn't fetch registration status",
+            error.message
+          ),
+      }
+    )
+  } else {
+    return {}
   }
-  return res
 }
 
-export const hasStakeInCourse = async (provider) => {
-  const { chainId } = await provider.getNetwork()
+export const useHasStakeInCourse = () => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
 
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    provider
+  return useContractRead(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'isDeployed',
+    {
+      args: KERNEL_COURSE_ID,
+      onError: (error) =>
+        queueNotification(
+          'error',
+          "Couldn't fetch deposit status",
+          error.message
+        ),
+    }
   )
-  let res = false
-  try {
-    res = !!(await deSchoolContract.isDeployed(KERNEL_COURSE_ID))
-  } catch (err) {
-    // throws an error if either the learner is not registered or if the courseId does not exist
-    /** */
+}
+
+export const useGetBlockRegistered = (learner) => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
+
+  return useContractRead(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'isDeployed',
+    {
+      args: [learner, KERNEL_COURSE_ID],
+      onError: (error) =>
+        queueNotification(
+          `Couldn't fetch block registered: ${error.message}`,
+          'error'
+        ),
+    }
+  )
+}
+
+export const useGetCourseLength = () => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
+
+  const { data } = useContractRead(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'isDeployed',
+    {
+      args: KERNEL_COURSE_ID,
+      onError: (error) =>
+        queueNotification(
+          'error',
+          "Couldn't fetch course length",
+          error.message
+        ),
+    }
+  )
+
+  return data ? data[1] : 0
+}
+
+export const useRedeemDeposit = () => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
+
+  return useContractWrite(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'redeem',
+    {
+      onError: (error) =>
+        queueNotification('error', 'Redemption failed', error.message),
+    }
+  )
+}
+
+export const useGetDaiNonce = (learner) => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
+
+  if (learner) {
+    return useContractRead(
+      {
+        addressOrName: addresses(chainId).dai,
+        contractInterface: abis.dai,
+      },
+      'nonces',
+      {
+        args: learner,
+        onError: (error) =>
+          queueNotification('error', "Couldn't fetch DAI nonce", error.message),
+      }
+    )
+  } else {
+    return {}
   }
-  return res
 }
 
-export const getBlockRegistered = async (learner, provider) => {
-  const { chainId } = await provider.getNetwork()
+export const useIsScholarshipAvailable = () => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
 
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    provider
+  return useContractRead(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'scholarshipAvailable',
+    {
+      args: KERNEL_COURSE_ID,
+      onError: (error) =>
+        queueNotification(
+          'error',
+          "Couldn't fetch scholarships",
+          error.message
+        ),
+    }
   )
-
-  let res
-  try {
-    res = await deSchoolContract.getBlockRegistered(learner, KERNEL_COURSE_ID)
-  } catch (err) {
-    // throws an error if either the learner is not registered or if the courseId does not exist
-    /** */
-  }
-  return res
 }
 
-export const getCourseLength = async (provider) => {
-  const { chainId } = await provider.getNetwork()
+export const useRegisterScholar = () => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
 
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    provider
+  return useContractWrite(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'registerScholar',
+    {
+      args: KERNEL_COURSE_ID,
+      onError: (error) =>
+        queueNotification('error', 'Registration failed', error.message),
+    }
   )
-
-  let res
-  try {
-    res = await deSchoolContract.courses(KERNEL_COURSE_ID)[1]
-  } catch (err) {
-    // throws an error if either the learner is not registered or if the courseId does not exist
-    /** */
-  }
-  return res
 }
 
-export const redeemDeposit = async (signer) => {
-  const chainId = await signer.getChainId()
+export const usePermitAndRegister = () => {
+  const chainId = useGetChainId()
+  const { queueNotification } = useNotifications()
 
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    signer
+  return useContractWrite(
+    {
+      addressOrName: addresses(chainId).deSchool,
+      contractInterface: abis.deSchool,
+    },
+    'permitAndRegister',
+    {
+      overrides: { gasLimit: 200000 },
+      onError: (error) =>
+        queueNotification('error', 'Registration failed', error.message),
+    }
   )
-
-  let res
-
-  try {
-    res = !!(await deSchoolContract.redeem(KERNEL_COURSE_ID))
-  } catch (err) {
-    // throws an error if either the learner is not registered or if the courseId does not exist
-    /** */
-  }
-
-  return res
-}
-
-export const getDaiNonce = async (learner, provider) => {
-  const { chainId } = await provider.getNetwork()
-
-  const daiContract = new Contract(addresses(chainId).dai, abis.dai, provider)
-
-  return await daiContract.nonces(learner)
-}
-
-export const getScholarshipAvailable = async (provider) => {
-  const { chainId } = await provider.getNetwork()
-
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    provider
-  )
-
-  return await deSchoolContract.scholarshipAvailable(KERNEL_COURSE_ID)
-}
-
-export const registerScholar = async (signer) => {
-  const chainId = await signer.getChainId()
-
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    signer
-  )
-
-  return await deSchoolContract.registerScholar(KERNEL_COURSE_ID)
-}
-
-export const permitAndRegister = async (signer, nonce, expiry, v, r, s) => {
-  const chainId = await signer.getChainId()
-
-  const deSchoolContract = new Contract(
-    addresses(chainId).deSchool,
-    abis.deSchool,
-    signer
-  )
-  let res = false
-  try {
-    res = !!(await deSchoolContract.permitAndRegister(
-      KERNEL_COURSE_ID,
-      nonce,
-      expiry,
-      v,
-      r,
-      s,
-      { gasLimit: 200000 }
-    ))
-  } catch (err) {
-    // Handle error
-    // console.log(err);
-  }
-  return res
 }

--- a/src/modules/redemptionPage/RedemptionConnector.js
+++ b/src/modules/redemptionPage/RedemptionConnector.js
@@ -1,37 +1,24 @@
 /** @jsx jsx */
 
 import { jsx } from 'theme-ui'
-import { useAccount, useProvider } from 'wagmi'
-import { useEffect, useState } from 'react'
 
-import { hasStakeInCourse } from '@src/course/contracts'
+import { useHasStakeInCourse } from '@src/course/contracts'
 import RegisterButton from './RegisterButton'
 import RedemptionDetails from './RedemptionDetails'
 
-const RedemptionConnector = () => {
-  const { data: accountData } = useAccount()
-  const provider = useProvider()
-  const [hasStakeStakeToRedeem, setHasStakeToRedeem] = useState(false)
+const RedemptionConnector = ({ address }) => {
+  const { data: hasStakeStakeToRedeem, isLoading } = useHasStakeInCourse()
 
-  useEffect(() => {
-    const retrieveAndSetStakeState = async () => {
-      const _hasStake = await hasStakeInCourse(provider)
-      setHasStakeToRedeem(_hasStake)
-    }
-
-    if (accountData?.address && provider) {
-      retrieveAndSetStakeState()
-    }
-  }, [accountData?.address, provider])
-
-  return (
-    <div>
-      {hasStakeStakeToRedeem && (
-        <RedemptionDetails address={accountData?.address} />
-      )}
-      {!hasStakeStakeToRedeem && <RegisterButton />}
-    </div>
-  )
+  if (isLoading) {
+    return <div>Loading...</div>
+  } else {
+    return (
+      <div>
+        {hasStakeStakeToRedeem && <RedemptionDetails address={address} />}
+        {!hasStakeStakeToRedeem && <RegisterButton />}
+      </div>
+    )
+  }
 }
 
 export default RedemptionConnector

--- a/src/modules/redemptionPage/RedemptionDetails.js
+++ b/src/modules/redemptionPage/RedemptionDetails.js
@@ -1,15 +1,15 @@
 /** @jsx jsx */
 
 import { Flex, jsx } from 'theme-ui'
-import { useConnect, useProvider, useBlockNumber, useSigner } from 'wagmi'
+import { useConnect, useBlockNumber } from 'wagmi'
 import { useEffect, useState } from 'react'
 
 import { Button as Web3Button } from '@src/modules/web3'
 import { Connector } from '@src/course/connect'
 import {
-  getBlockRegistered,
-  getCourseLength,
-  redeemDeposit,
+  useGetBlockRegistered,
+  useGetCourseLength,
+  useRedeemDeposit,
 } from '@src/course/contracts'
 
 const isRedemptionTime = (currentBlockNumber, redemptionBlockNumber) => {
@@ -20,7 +20,9 @@ const getTimeUntilRedemptionText = (
   currentBlockNumber,
   redemptionBlockNumber
 ) => {
-  if (isRedemptionTime(currentBlockNumber, redemptionBlockNumber)) {
+  if (!redemptionBlockNumber || redemptionBlockNumber === 0) {
+    return 'No deposit found for the current address'
+  } else if (isRedemptionTime(currentBlockNumber, redemptionBlockNumber)) {
     return 'You can redeem your deposit now'
   } else {
     const averageBlockTimeInDays = 14 / 60 / 60 / 24
@@ -38,38 +40,21 @@ const getTimeUntilRedemptionText = (
 }
 
 const RedemptionDetails = ({ address }) => {
-  const provider = useProvider()
-  const { data: signer } = useSigner()
+  const { write: redeemDeposit } = useRedeemDeposit()
   const { data: currentBlockNumber } = useBlockNumber({ watch: true })
   const { connectors } = useConnect()
 
   const [connector] = useState(connectors[Connector.INJECTED])
-  const [blockRegistered, setBlockRegistered] = useState(0)
-  const [courseLength, setCourseLength] = useState(0)
   const [canRedeemDeposit, setCanRedeemDeposit] = useState(false)
+
+  const { data: blockRegistered } = useGetBlockRegistered(address)
+  const courseLength = useGetCourseLength()
 
   const redemptionBlockNumber = blockRegistered + courseLength
   const timeUntilRedemptionText = getTimeUntilRedemptionText(
     currentBlockNumber,
     redemptionBlockNumber
   )
-
-  useEffect(() => {
-    const retrieveBlockRegistered = async () => {
-      const blockNumber = await getBlockRegistered(address, provider)
-      setBlockRegistered(blockNumber || 0)
-    }
-
-    const retrieveCourseLength = async () => {
-      const lengthOfCourse = await getCourseLength(provider)
-      setCourseLength(lengthOfCourse || 0)
-    }
-
-    if (address && provider) {
-      retrieveBlockRegistered()
-      retrieveCourseLength()
-    }
-  }, [address, provider])
 
   useEffect(() => {
     if (currentBlockNumber && blockRegistered) {
@@ -80,7 +65,7 @@ const RedemptionDetails = ({ address }) => {
   }, [blockRegistered, currentBlockNumber])
 
   const handleOnPressRedeem = async () => {
-    await redeemDeposit(signer)
+    await redeemDeposit()
   }
 
   return (

--- a/src/pages/en/redeem.js
+++ b/src/pages/en/redeem.js
@@ -1,18 +1,19 @@
 /** @jsx jsx */
 
 import { Flex, jsx } from 'theme-ui'
-import { useConnect } from 'wagmi'
+import { useConnect, useAccount } from 'wagmi'
 
 import { Heading } from '@modules/ui/heading'
 import { ConnectButton, RedemptionConnector } from '@src/modules/redemptionPage'
 
 const RedeemPage = () => {
   const { isConnected } = useConnect()
+  const { data: accountData } = useAccount()
 
   return (
     <Flex sx={styles.container}>
       <Heading level={1}>Redeem</Heading>
-      {isConnected && <RedemptionConnector />}
+      {isConnected && <RedemptionConnector address={accountData?.address} />}
       {!isConnected && <ConnectButton />}
     </Flex>
   )


### PR DESCRIPTION
This commit refactors our contract calls to use the wagmi hooks syntax.

Each of our contract calls were also rewritten as hooks to allow use to
stack the new notification functionality on top of the contract calls.

This lets us easily notifications plug into the `onError` and other
callback functions given on the wagmi `useContractRead` and
`useContractWrite` functions.

Another nice benefit of using the contract hooks is that we can avoid
having to state but being able to directly use the result of the call
instead of having to wait for an async result.