### PR TITLE
Support multiple AudioPlayer components per page

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "sharp": "^0.30.2",
     "theme-ui": "^0.14.5",
     "use-immer": "^0.6.0",
+    "uuid": "^8.3.2",
     "wagmi": "^0.2.6",
     "window-or-global": "^1.0.1"
   },

--- a/src/modules/audioPlayer/Audio.js
+++ b/src/modules/audioPlayer/Audio.js
@@ -1,8 +1,8 @@
 import React from 'react'
 
-const Audio = ({ src }) => {
+const Audio = ({ src, playerId }) => {
   return (
-    <audio id="audio">
+    <audio id={playerId}>
       <source src={src} />
       Your browser does not support the <code>audio</code> element.
     </audio>

--- a/src/modules/audioPlayer/ProgressBar.js
+++ b/src/modules/audioPlayer/ProgressBar.js
@@ -2,7 +2,7 @@
 import { jsx } from 'theme-ui'
 import { format, addSeconds } from 'date-fns'
 
-const ProgressBar = ({ currentTime, duration, onTimeUpdate }) => {
+const ProgressBar = ({ currentTime, duration, onTimeUpdate, playerId }) => {
   const percentProgress = (currentTime / duration) * 100
 
   const formatDuration = (duration) => {
@@ -10,8 +10,10 @@ const ProgressBar = ({ currentTime, duration, onTimeUpdate }) => {
     return format(durationTime, 'mm:ss')
   }
 
+  const progressBarId = `progressBar-${playerId}`
+
   const getTimeAtPosition = (e) => {
-    const bar = document.getElementById('progressBar')
+    const bar = document.getElementById(progressBarId)
     const barStart = bar.getBoundingClientRect().left
     const barWidth = bar.offsetWidth
     const clickPositionInPage = e.pageX
@@ -46,7 +48,10 @@ const ProgressBar = ({ currentTime, duration, onTimeUpdate }) => {
   return (
     <div sx={styles.container}>
       <span sx={styles.timeText}>{formatDuration(currentTime)}</span>
-      <div id="progressBar" style={barStyle} onMouseDown={handleBarInteraction}>
+      <div
+        id={progressBarId}
+        style={barStyle}
+        onMouseDown={handleBarInteraction}>
         <span sx={knobStyle} />
       </div>
       <span sx={styles.timeText}>{formatDuration(duration)}</span>

--- a/src/modules/audioPlayer/index.js
+++ b/src/modules/audioPlayer/index.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { useState, useEffect } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 import ProgressBar from './ProgressBar'
 import Audio from './Audio'
@@ -11,9 +12,15 @@ const AudioPlayer = ({ src }) => {
   const [currentTime, setCurrentTime] = useState(0)
   const [isPlaying, setIsPlaying] = useState(false)
   const [clickedTime, setClickedTime] = useState()
+  const [playerId, setPlayerId] = useState()
 
   useEffect(() => {
-    const audio = document.getElementById('audio')
+    const uuid = uuidv4()
+    setPlayerId(`audio-${uuid}`)
+  }, [])
+
+  useEffect(() => {
+    const audio = document.getElementById(playerId)
 
     const setAudioData = () => {
       setDuration(audio.duration)
@@ -36,7 +43,7 @@ const AudioPlayer = ({ src }) => {
       audio.removeEventListener('loadeddata', setAudioData)
       audio.removeEventListener('timeupdate', setAudioTime)
     }
-  }, [isPlaying, clickedTime])
+  }, [playerId, isPlaying, clickedTime])
 
   const handleOnClickPlayControl = () => {
     setIsPlaying(!isPlaying)
@@ -44,7 +51,7 @@ const AudioPlayer = ({ src }) => {
 
   return (
     <div sx={styles.container}>
-      <Audio src={src} />
+      <Audio src={src} playerId={playerId} />
       <PlayControl
         isPlaying={isPlaying}
         handleOnClick={handleOnClickPlayControl}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15169,6 +15169,11 @@ uuid@3.4.0, uuid@^3.0.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz"


### PR DESCRIPTION
This commit enables multiple AudioPlayer instances for a given page.
Internally, the audio player code was referring to DOM elements by
static IDs, and so any additional audio players added to the page would
end up pointing at the first components DOM elements.

The fix here adds a UUID generation library to generate a UUID and
append it to the various DOM IDs that we use for handling audio-related
events.