### PR TITLE
Learn Track Simplicity 

### DIFF
--- a/content/en/learn/index.mdx
+++ b/content/en/learn/index.mdx
@@ -13,12 +13,7 @@ hideLanguageSelector: true
 
 # Learn About a Better Web
 
-![Learn](/images/kernel_process.png)
-
 </Box>
-
-## 📖 Learn Track Structure
-
 | Title                                              | Personal Inquiry                                              | Web 3 Enquiry                                                      |
 | -------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------- |
 | 🌠 [Introduction to Kernel](/learn/module-0)       | 🌈 [The Play of Pattern](/learn/module-0/play-of-pattern)     | ✍️ [Trust](/learn/module-0/trust)                                 |


### PR DESCRIPTION
To return again, to the simplicity of the eightfold structure. Removes the image and the subheading, goes directly into the 8 chapters of the book. 

In the future, could also add Module Mettā to this page, but I do like the fact that it is an extra addendum for now. 