### PR TITLE
Mentors

### DIFF
--- a/content/en/guiding/guides/mentors.mdx
+++ b/content/en/guiding/guides/mentors.mdx
@@ -5,32 +5,41 @@ hideLanguageSelector: true
 featuredImage: images/shares/giving.png
 ---
 
+
 # Maintaining Mentors
 
 Mentor is the name of Telemachus' adviser is _The Odyssey_. Its etumology points at one who is a "wise adviser or intimate friend, an also a sage counselor". This being Kernel, we're most excited about the notion of **intimate friendship**.
 
 Mentors, first and foremost, are our friends. While you may not have been through an entire Kernel block yourself, you have inspired some of the thoughts in the syllabus, or helped the stewards along their own learning paths, or brought people into the community who need to be here in order for necessary conversations to unfold.
 
-You are an inspiration to us and, being friends, we feel the need to share that inspiration with those people just beginning their Kernel experience. In particular, your specific expertise and experience within the industry means that we feel you can provide the kinds of sage and wise advice we would not otherwise be able to find.
+You are an inspiration to us and we feel the need to share that inspiration with those people just beginning their Kernel experience. In particular, your specific expertise and experience within the industry means that we feel you can provide the kinds of sage and wise advice we would not otherwise be able to find.
 
-Before reading any further, please know that we are truly grateful for the time and insights you continually offer to Kernel.
+Before reading any further, please know that we are truly grateful for the time and insights you offer to Kernel.
+
+
+<iframe class="airtable-embed" src="https://airtable.com/embed/apptqJRyRxZ0QDi3h/pagu3wAhXQ9zGca4h/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
 
 ## Making The Office Ours Again
 
-Mentors have one, primary role:
+Mentors have two primary roles:
 
-> Make Friday Office Hours awesome.
+1. Make Wednesday Office Hours awesome.
 
-During each block, we host a 1-1:30hr "Office Hours" event in which Kernel Fellows get to meet and interact with industry experts who also happen to be dear friends of ours. They can pitch their ideas, or discuss problems, or experiment with different ways of looking at what they want to achieve. Our ask of the mentors is to show up, **listen attentively**, and help in whatever way you can.
+During each block, we host a 1hr "Office Hours" event in which Kernel Fellows get to meet and interact with industry experts who also happen to be dear friends of ours. They can pitch their ideas, or discuss problems, or experiment with different ways of looking at what they want to achieve. Our ask of the mentors is to show up, **listen attentively**, and help in whatever way you can.
 
 This help is not limited to any one thing. It can be technical advice; pointed and specific questions about product-market fit; strategic analysis; design and user experience insights; offers for funding or investment; connections to other developers/designers/DAOs/VCs who are better placed to help; instructive stories about your own experience with similar ideas or products and so on.
 
 We want to make Kernel Office Hours into an [institution](/learn/module-4) in the sense of a practice or custom around which many different people can gather in order to advance their own, diverse ideas about - and ways of practicing - excellence. We can only do that with your help.
 
+2. Be the assigned KBX Mentor to 1-2 Kernel Fellows (and their projects).
+
+You will meet with the project(s) at least 2 times in the block, depending on your availability and preference. 
+
 ## Giving is Receiving
 
 Of course, providing this help is not a one-way street. By agreeing to mentor Kernel Fellows each Friday (or, if you really need, on a more bespoke schedule), we hope that you find alpha in at least two ways. First, insightful time spent exploring the latest, greatest ideas in web3. Second, through friendships which make it possible to play infinite games and relate more freely.
 
-Kernel is an opportunity to serve, and Office Hours is your place of practice.
+Kernel is an opportunity to serve and is a place of practice.
 
 > Why do we serve? At first, it is because we know intellectually that it is a noble and pure-hearted way to live; a means of seeing, understanding, and working against the subtler parts of our ego. Later on, it is because we wish to experience how the people we serve are simply reflections of our self; how there is no true division between us and them. We serve to see our self in others; to be without separation.

--- a/content/en/guiding/guides/mentors.mdx
+++ b/content/en/guiding/guides/mentors.mdx
@@ -22,7 +22,7 @@ Before reading any further, please know that we are truly grateful for the time 
 
 ## Making The Office Ours Again
 
-Mentors have two primary roles:
+Mentors have two primary roles. Consider both options as you chart your own, unique path through Kernel.
 
 1. Make Wednesday Office Hours awesome.
 
@@ -34,7 +34,7 @@ We want to make Kernel Office Hours into an [institution](/learn/module-4) in th
 
 2. Be the assigned KBX Mentor to 1-2 Kernel Fellows (and their projects).
 
-You will meet with the project(s) at least 2 times in the block, depending on your availability and preference. 
+You will meet with the project(s) at least 2 times, depending on your availability and preference. 
 
 ## Giving is Receiving
 


### PR DESCRIPTION
Update the mentors page with an embed link to the active, infinite Kernel Mentors form. 

Considering adding a link to schedule a call with a Kernel Steward next, if this works properly.