### PR TITLE
Twitter Image Unfurls + Fix Akasha Image + Eigen Nit

### DIFF
--- a/blogPosts/en/blog/Editorial/akasha-concordance.mdx
+++ b/blogPosts/en/blog/Editorial/akasha-concordance.mdx
@@ -4,7 +4,7 @@ authors: ["maceagonvoyce"]
 keywords: "kernel, fellows, features, concordance, anoma"
 description: "If you can manage state reliably, then you can start to build more sophisticated coordination logic – and dabble in shared realities."
 date: 2025-07-19
-image: "/images/blog_headers/Akasha_NoSig_Blog"
+image: "/images/blog_headers/Akasha_NoSig_Blog.png"
 recommend:
   [
     "blogPosts/en/blog/Editorial/what-is-privacy",

--- a/blogPosts/en/blog/Editorial/john-astral.mdx
+++ b/blogPosts/en/blog/Editorial/john-astral.mdx
@@ -95,8 +95,8 @@ For rabbit hole dwellers, we ask each featured fellow to share some deeper techn
 
 These are John’s:
 
-[A Guide to Coordinate Systems in Great Britain](https://www.ordnancesurvey.co.uk/documents/resources/guide-coordinate-systems-great-britain.pdf)
-[How To Read Water](https://www.naturalnavigator.com/how-to-read-water/)
-[The FOAM Whitepaper](https://foam.space/publicAssets/FOAM_Whitepaper.pdf)
+- [A Guide to Coordinate Systems in Great Britain](https://www.ordnancesurvey.co.uk/documents/resources/guide-coordinate-systems-great-britain.pdf)
+- [How To Read Water](https://www.naturalnavigator.com/how-to-read-water/)
+- [The FOAM Whitepaper](https://foam.space/publicAssets/FOAM_Whitepaper.pdf)
 
 Building something interesting? Come and join us. [Apply for KB11](https://apply.kernel.community/11).

--- a/blogPosts/en/blog/Editorial/john-astral.mdx
+++ b/blogPosts/en/blog/Editorial/john-astral.mdx
@@ -59,7 +59,7 @@ For the past year, John and Adam have been working with Dr. Taylor Oshan, an ass
 
 They’ve been exploring Proof of Location (PoL) systems via their [Location Protocol](https://docs.astral.global/location-protocol/introduction) – signed, structured claims that describe place, time, and identity. It’s built on the Ethereum Attestation Service (EAS) – an open-source protocol that enables anyone to create and verify cryptographically signed claims about anything.
 
-What makes Location Protocol scalable is the combination of EAS's attestation infrastructure and Ethereum's EigenLayer, a restaking protocol that empowers validators to verify applications and protocols beyond the Ethereum ecosystem – inheriting Ethereum's security without bootstrapping their own validator set from scratch.
+What makes Location Protocol scalable is the combination of EAS's attestation infrastructure and EigenLayer, a restaking protocol that empowers validators to verify applications and protocols beyond the Ethereum ecosystem – inheriting Ethereum's security without bootstrapping their own validator set from scratch.
 
 Astral built EigenLocation AVS (Actively Validated Service, a custom validation network), which verifies location proofs and runs geospatial computation – think geofencing (e.g. ride-sharing apps detecting airport arrivals) and proximity matching (e.g. dating apps showing matches within a certain radius). (Location Protocol is live on Celo, Base, Arbitrum, and Ethereum Sepolia.)
 

--- a/src/modules/layouts/blogPost_layout.js
+++ b/src/modules/layouts/blogPost_layout.js
@@ -119,6 +119,7 @@ export default ({ children, pageContext }) => {
     title,
     description,
     keywords,
+    featuredImage: postImage,
   }
 
   return (

--- a/src/modules/utility/seo.js
+++ b/src/modules/utility/seo.js
@@ -79,11 +79,11 @@ function SEO({ description, lang, meta, title, keywords, url, featuredImage }) {
         },
         {
           property: 'og:image',
-          content: `https://read.kernel.community/${featuredImage}`,
+          content: featuredImage?.startsWith('http') ? featuredImage : `https://read.kernel.community${featuredImage}`,
         },
         {
           name: 'twitter:image',
-          content: `https://read.kernel.community/${featuredImage}`,
+          content: featuredImage?.startsWith('http') ? featuredImage : `https://read.kernel.community${featuredImage}`,
         },
         {
           name: `twitter:description`,


### PR DESCRIPTION
1) Akasha image was broken, fixed. 
2) Cursor helped me write some code to generate Twitter (and ideally all social media) unfurl images for blog posts, pulling the header image.  

This should fix the issue below. I wasn't able to test locally (had some issues), can do so tomorrow if it looks fishy upon review.

<img width="624" height="460" alt="image" src="https://github.com/user-attachments/assets/931f2b5f-8051-4597-9648-fa5436d10516" />
